### PR TITLE
Build declaration files with TSC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 package-lock.json
 test.js
+dist

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "Contiguity's JavaScript SDK",
   "main": "src/index.js",
+  "types": "dist/index.d.ts",
   "keywords": [
     "sms",
     "email",
@@ -11,11 +12,18 @@
   ],
   "author": "Contiguity",
   "license": "MIT",
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "fs": "^0.0.1-security",
     "html-minifier": "^4.0.0",
     "isomorphic-unfetch": "^4.0.2",
     "phone": "^3.1.37"
+  },
+  "devDependencies": {
+    "@types/node": "^20.3.1",
+    "typescript": "^5.1.3"
   },
   "repository": "https://github.com/use-contiguity/javascript.git"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+// https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html
+
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}


### PR DESCRIPTION
This uses JSDoc comments to create `.d.ts` files for TS users. Run `npm urn build` before publishing to NPM.